### PR TITLE
Make the script 'tweetable'

### DIFF
--- a/tiny-twitch.html
+++ b/tiny-twitch.html
@@ -1,1 +1,1 @@
-<script>var e,s=0,t=Date.now();function f(){((e=Date.now()-t)<15000)?a.style.margin=++s+e%300:alert(s)}</script><p id="a" onclick="f()">X
+<script>var e,s=0,t=Date.now();function f(){((e=Date.now()-t)<15000)?a['style'].margin=++s+e%300:alert(s)}</script><p id="a" onclick="f()">X


### PR DESCRIPTION
Hi there,

since most of the Twitter clients detect links automaticly, the part `a.style` in your script is considered as a link. Twitter tries to replace it by a shortened URL and the script cannot be tweeted. This small commit allows you script to be tweeted (and add 2 more characters).

Best,

Pierre
